### PR TITLE
Update mappings.cairo

### DIFF
--- a/listings/ch00-introduction/mappings/src/mappings.cairo
+++ b/listings/ch00-introduction/mappings/src/mappings.cairo
@@ -1,6 +1,5 @@
 #[contract]
 mod MapContract {
-    use starknet::get_caller_address;
     use starknet::ContractAddress;
 
     struct Storage {


### PR DESCRIPTION
unused import statement.
use starknet::get_caller_address; is not being utilized within the contract functions.