### PR TITLE
added links to contracts on Voyager

### DIFF
--- a/src/ch00-01-variables.md
+++ b/src/ch00-01-variables.md
@@ -23,6 +23,7 @@ Here's a simple example of a contract with only local variables:
 ```rust
 {{#include ../listings/ch00-introduction/variables/src/local_variables.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x015B3a10F9689BeD741Ca3C210017BC097122CeF76f3cAA191A20ff8b9b56b96).
 
 ## Storage Variables
 
@@ -37,6 +38,7 @@ Here's a simple example of a contract with one storage variable:
 ```rust
 {{#include ../listings/ch00-introduction/variables/src/storage_variables.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x06eA827B32875483709b785A7F9e846a52776Cd8D42C3fE696218c2624b0DCCa).
 
 ## Global Variables
 
@@ -49,3 +51,4 @@ For example, the `get_caller_address` function returns the address of the caller
 ```rust
 {{#include ../listings/ch00-introduction/variables/src/global_variables.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x05bD2F3943bd4e030f85678b55b2EC2C1be939e32388530FB20ED967B3Be433F).

--- a/src/ch00-02-errors.md
+++ b/src/ch00-02-errors.md
@@ -18,6 +18,7 @@ Here's a simple example that demonstrates the use of these functions:
 ```rust
 {{#include ../listings/ch00-introduction/errors/src/simple_errors.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x0022664463FF0b711CC9B549a9E87d65A0882bB1D29338C4108696B8F2216a40).
 
 ## Custom errors
 
@@ -26,6 +27,7 @@ You can make error handling easier by defining your error codes in a specific mo
 ```rust
 {{#include ../listings/ch00-introduction/errors/src/custom_errors.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x0501CD5da5B453a18515B5A20b8029bd7583DFE7a399ad9f79c284F7829e4A57).
 
 ## Vault example
 
@@ -34,3 +36,4 @@ Here's another example that demonstrates the use of errors in a more complex con
 ```rust
 {{#include ../listings/ch00-introduction/errors/src/vault_errors.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x020C2da26F42A28Ef54ED428eF1810FE433784b055f9bF315C5d992b1579C268).

--- a/src/ch00-03-calling_other_contracts.md
+++ b/src/ch00-03-calling_other_contracts.md
@@ -12,7 +12,9 @@ In order to call other contracts using dispatchers, you will need to define the 
 ```rust
 {{#include ../listings/ch00-introduction/calling_other_contracts/src/callee.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x015c3Bb6D0DE26b64FEAF9A8f4655CfADb5c128bF4510398972704ee12775DB1).
 
 ```rust
 {{#include ../listings/ch00-introduction/calling_other_contracts/src/caller.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x05fa8aF796343d2f22c53C17149386b67B7AC4aB52D9e308Aa507C185aA44778).

--- a/src/ch00-06-mappings.md
+++ b/src/ch00-06-mappings.md
@@ -13,3 +13,4 @@ Some additional notes:
 ```rust
 {{#include ../listings/ch00-introduction/mappings/src/mappings.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x06214AB4c23Cc545bf2221D465eB83aFb7412779AD498BD48a724B3F645E3505).

--- a/src/ch00-07-constructor.md
+++ b/src/ch00-07-constructor.md
@@ -7,3 +7,4 @@ Here's a simple example that demonstrates how to initialize the state of a contr
 ```rust
 {{#include ../listings/ch00-introduction/constructor/src/lib.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x017fd6558e67451dA583d123D77F4e2651E91502D08F8F8432355293b11e1f8F).

--- a/src/ch00-08-visibility-mutability.md
+++ b/src/ch00-08-visibility-mutability.md
@@ -27,3 +27,4 @@ Let's take a look at a simple example contract to see these in action:
 ```rust
 {{#include ../listings/ch00-introduction/visibility/src/visibility.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x0071dE3093AB58053b0292C225aa0eED40293e7694A0042685FF6D813d39889F).

--- a/src/ch00-10-events.md
+++ b/src/ch00-10-events.md
@@ -8,3 +8,4 @@ Here's a simple example of a contract using events that emit an event each time 
 ```rust
 {{#include ../listings/ch00-introduction/events/src/counter.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x022e3B59518EA04aBb5da671ea04ecC3a154400f226d2Df38eFE146741b9E2F6).

--- a/src/ch00-11-counter.md
+++ b/src/ch00-11-counter.md
@@ -13,3 +13,4 @@ Here's how it works:
 ```rust
 {{#include ../listings/ch00-introduction/counter/src/counter.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x01664a69Fe701a1df7Bb0ae4A353792d0cf4E27146ee860075cbf6108b1D5718).

--- a/src/ch01-01-write_to_any_slot.md
+++ b/src/ch01-01-write_to_any_slot.md
@@ -11,3 +11,4 @@ In the following example, we use the Poseidon hash function to compute the addre
 ```rust
 {{#include ../listings/ch01-advanced-concepts/write_to_any_slot/src/write_any_slot.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x033943CB781A4E63C9dcE0A1A09eAa3b617AA43CC61637C08c043a67f3fe0087).

--- a/src/ch01-02-storing_arrays.md
+++ b/src/ch01-02-storing_arrays.md
@@ -13,3 +13,4 @@ You can then import this implementation in your contract and use it to store arr
 ```rust
 {{#include ../listings/ch01-advanced-concepts/storing_arrays/src/storing_arrays.cairo:StoreArrayContract}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x008F8069a3Fcd7691Db46Dc3b6F9D2C0436f9200E861330957Fd780A3595da86).

--- a/src/ch02-01-upgradeable_contract.md
+++ b/src/ch02-01-upgradeable_contract.md
@@ -25,7 +25,9 @@ Start by deploying `UpgradeableContract_V0` as the initial version. Next, send a
 ```rust
 {{#include ../listings/ch02-applications/upgradeable_contract/src/upgradeable_contract_v0.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x005300003ade5d10447d941a42d48b7141074cd8bade2b16520684896a5090ea).
 
 ```rust
 {{#include ../listings/ch02-applications/upgradeable_contract/src/upgradeable_contract_v1.cairo}}
 ```
+Visit contract on [Voyager](https://goerli.voyager.online/contract/0x017c86152badd1d665b9836571bd6b0a484f028748aa13d9b2d5d9c9192fafc6).


### PR DESCRIPTION
Added links to contracts on Voyager

**Not included:**
Defi vault: got error during declare class
`Error: StarkException: (400, {'code': <StarknetErrorCode.COMPILATION_FAILED: 3>, 'message': "Compilation failed. Error: Libfunc u256_safe_divmod is not allowed in the libfuncs list '/home/cxn/starknetbyexample/venv/lib/python3.9/site-packages/starkware/starknet/compiler/v1/testnet_libfuncs.json'.\n Run with '--allowed-libfuncs-list-name all' to allow all libfuncs.\n"})`

**Bugs on Voyager end**
Propose to wait with merging until bugs are fixed.

1. wrong Cairo version, being fixed atm
[state mutability](https://goerli.voyager.online/contract/0x0071dE3093AB58053b0292C225aa0eED40293e7694A0042685FF6D813d39889F)
[local var](https://goerli.voyager.online/contract/0x015B3a10F9689BeD741Ca3C210017BC097122CeF76f3cAA191A20ff8b9b56b96)
2. internal calls issue for all deploy tx, fix ready but yet to push to master
eg: internal calls tab of [following tx](https://goerli.voyager.online/tx/0x2969f5c6f248950ba59180aa984890ce372cdda0082c758d0647b9fb9c80bcd#overview)
