### PR TITLE
ci: restore setup-rust-cache

### DIFF
--- a/.github/workflows/setup-rust-cache/action.yml
+++ b/.github/workflows/setup-rust-cache/action.yml
@@ -1,0 +1,9 @@
+name: Setup Rust cache
+
+description: Configure the rust-cache workflow.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
While rust cache is no longer necessary when running [verify_cairo_programs](https://github.com/NethermindEth/StarknetByExample/blob/main/.github/workflows/verify_cairo_programs.yml) with setup scarb action, it's still used during the book building process.