### PR TITLE
fix: remove external(v0) usage on impl blocks

### DIFF
--- a/listings/ch00-getting-started/calling_other_contracts/src/callee.cairo
+++ b/listings/ch00-getting-started/calling_other_contracts/src/callee.cairo
@@ -5,7 +5,7 @@ mod Callee {
         value: u128,
     }
 
-    #[external(v0)]
+    #[abi(per_item)]
     #[generate_trait]
     impl ICalleeImpl of ICallee {
         fn set_value(ref self: ContractState, value: u128) -> u128 {

--- a/listings/ch00-getting-started/calling_other_contracts/src/caller.cairo
+++ b/listings/ch00-getting-started/calling_other_contracts/src/caller.cairo
@@ -16,8 +16,8 @@ mod Caller {
     #[storage]
     struct Storage {}
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl ICallerImpl of ICaller {
         fn set_value_from_address(ref self: ContractState, addr: ContractAddress, value: u128) {
             ICalleeDispatcher { contract_address: addr }.set_value(value);

--- a/listings/ch00-getting-started/counter/src/counter.cairo
+++ b/listings/ch00-getting-started/counter/src/counter.cairo
@@ -5,7 +5,6 @@ trait ISimpleCounter<TContractState> {
     fn decrement(ref self: TContractState);
 }
 
-
 #[starknet::contract]
 mod SimpleCounter {
     #[storage]
@@ -20,9 +19,8 @@ mod SimpleCounter {
         self.counter.write(init_value);
     }
 
-    #[generate_trait]
-    #[external(v0)]
-    impl SimpleCounter of ISimpleCounter {
+    #[abi(embed_v0)]
+    impl SimpleCounter of super::ISimpleCounter<ContractState> {
         fn get_current_count(self: @ContractState) -> u256 {
             return self.counter.read();
         }

--- a/listings/ch00-getting-started/custom_type_serde/src/contract.cairo
+++ b/listings/ch00-getting-started/custom_type_serde/src/contract.cairo
@@ -10,10 +10,14 @@ mod SerdeCustomType {
         age: u8,
         name: felt252
     }
-    #[external(v0)]
+
+    #[abi(per_item)]
     #[generate_trait]
     impl SerdeCustomType of ISerdeCustomType {
+        #[external(v0)]
         fn person_input(ref self: ContractState, person: Person) {}
+
+        #[external(v0)]
         fn person_output(self: @ContractState) -> Person {
             Person { age: 10, name: 'Joe' }
         }

--- a/listings/ch00-getting-started/errors/src/custom_errors.cairo
+++ b/listings/ch00-getting-started/errors/src/custom_errors.cairo
@@ -10,13 +10,15 @@ mod CustomErrorsExample {
     #[storage]
     struct Storage {}
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl CustomErrorsExample of ICustomErrorsExample {
+        #[external(v0)]
         fn test_assert(self: @ContractState, i: u256) {
             assert(i > 0, Errors::NOT_POSITIVE);
         }
 
+        #[external(v0)]
         fn test_panic(self: @ContractState, i: u256) {
             if (i == 0) {
                 panic_with_felt252(Errors::NOT_NULL);

--- a/listings/ch00-getting-started/errors/src/simple_errors.cairo
+++ b/listings/ch00-getting-started/errors/src/simple_errors.cairo
@@ -3,15 +3,17 @@ mod ErrorsExample {
     #[storage]
     struct Storage {}
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl ErrorsExample of IErrorsExample {
+        #[external(v0)]
         fn test_assert(self: @ContractState, i: u256) {
             // Assert used to validate a condition
             // and abort execution if the condition is not met
             assert(i > 0, 'i must be greater than 0');
         }
 
+        #[external(v0)]
         fn test_panic(self: @ContractState, i: u256) {
             if (i == 0) {
                 // Panic used to abort execution directly

--- a/listings/ch00-getting-started/errors/src/vault_errors.cairo
+++ b/listings/ch00-getting-started/errors/src/vault_errors.cairo
@@ -12,15 +12,17 @@ mod VaultErrorsExample {
         balance: u256,
     }
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl VaultErrorsExample of IVaultErrorsExample {
+        #[external(v0)]
         fn deposit(ref self: ContractState, amount: u256) {
             let mut balance = self.balance.read();
             balance = balance + amount;
             self.balance.write(balance);
         }
 
+        #[external(v0)]
         fn withdraw(ref self: ContractState, amount: u256) {
             let mut balance = self.balance.read();
 

--- a/listings/ch00-getting-started/events/Scarb.toml
+++ b/listings/ch00-getting-started/events/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
-name = "counter"
+name = "events"
 version = "0.1.0"
 
 [dependencies]

--- a/listings/ch00-getting-started/events/src/counter.cairo
+++ b/listings/ch00-getting-started/events/src/counter.cairo
@@ -31,9 +31,10 @@ mod EventCounter {
         new_value: u128,
     }
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl EventCounter of IEventCounter {
+        #[external(v0)]
         fn increment(ref self: ContractState) {
             let mut counter = self.counter.read();
             counter += 1;

--- a/listings/ch00-getting-started/interfaces_traits/src/explicit.cairo
+++ b/listings/ch00-getting-started/interfaces_traits/src/explicit.cairo
@@ -6,15 +6,13 @@ trait IExplicitInterfaceContract<TContractState> {
 
 #[starknet::contract]
 mod ExplicitInterfaceContract {
-    use super::IExplicitInterfaceContract;
-
     #[storage]
     struct Storage {
         value: u32
     }
 
-    #[external(v0)]
-    impl ExplicitInterfaceContract of IExplicitInterfaceContract<ContractState> {
+    #[abi(embed_v0)]
+    impl ExplicitInterfaceContract of super::IExplicitInterfaceContract<ContractState> {
         fn get_value(self: @ContractState) -> u32 {
             self.value.read()
         }

--- a/listings/ch00-getting-started/interfaces_traits/src/implicit.cairo
+++ b/listings/ch00-getting-started/interfaces_traits/src/implicit.cairo
@@ -5,13 +5,15 @@ mod ImplicitInterfaceContract {
         value: u32
     }
 
-    #[external(v0)]
+    #[abi(per_item)]
     #[generate_trait]
     impl ImplicitInterfaceContract of IImplicitInterfaceContract {
+        #[external(v0)]
         fn get_value(self: @ContractState) -> u32 {
             self.value.read()
         }
 
+        #[external(v0)]
         fn set_value(ref self: ContractState, value: u32) {
             self.value.write(value);
         }

--- a/listings/ch00-getting-started/interfaces_traits/src/implicit_internal.cairo
+++ b/listings/ch00-getting-started/interfaces_traits/src/implicit_internal.cairo
@@ -16,6 +16,7 @@ mod ImplicitInternalContract {
 
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
+        #[external(v0)]
         fn set_value(ref self: ContractState, value: u32) {
             self.value.write(value);
         }
@@ -29,7 +30,7 @@ mod ImplicitInternalContract {
         self.set_value(0);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ImplicitInternalContract of IImplicitInternalContract<ContractState> {
         fn add(ref self: ContractState, nb: u32) {
             self.set_value(self.value.read() + nb);

--- a/listings/ch00-getting-started/mappings/src/mappings.cairo
+++ b/listings/ch00-getting-started/mappings/src/mappings.cairo
@@ -8,13 +8,15 @@ mod MapContract {
         map: LegacyMap::<ContractAddress, felt252>,
     }
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl MapContractImpl of IMapContract {
+        #[external(v0)]
         fn set(ref self: ContractState, key: ContractAddress, value: felt252) {
             self.map.write(key, value);
         }
 
+        #[external(v0)]
         fn get(self: @ContractState, key: ContractAddress) -> felt252 {
             self.map.read(key)
         }

--- a/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
@@ -13,12 +13,15 @@ mod StoringCustomType {
         name: felt252
     }
 
-    #[external(v0)]
+    #[abi(per_item)]
     #[generate_trait]
     impl StoringCustomType of IStoringCustomType {
+        #[external(v0)]
         fn set_person(ref self: ContractState) {
             self.person.write(Person { age: 10, name: 'Joe' });
         }
+
+        #[external(v0)]
         fn get_person(self: @ContractState) {
             self.person.read();
         }

--- a/listings/ch00-getting-started/testing/src/contract.cairo
+++ b/listings/ch00-getting-started/testing/src/contract.cairo
@@ -23,7 +23,7 @@ mod SimpleContract {
         self.owner.write(get_caller_address());
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl SimpleContract of super::ISimpleContract<ContractState> {
         fn get_value(self: @ContractState) -> u32 {
             self.value.read()

--- a/listings/ch00-getting-started/variables/src/global_variables.cairo
+++ b/listings/ch00-getting-started/variables/src/global_variables.cairo
@@ -6,9 +6,10 @@ mod GlobalExample {
     #[storage]
     struct Storage {}
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl GlobalExampleImpl of IGlobalExample {
+        #[external(v0)]
         fn foo(ref self: ContractState) {
             // Call the get_caller_address function to get the sender address
             let caller = get_caller_address();

--- a/listings/ch00-getting-started/variables/src/local_variables.cairo
+++ b/listings/ch00-getting-started/variables/src/local_variables.cairo
@@ -3,9 +3,10 @@ mod LocalVariablesExample {
     #[storage]
     struct Storage {}
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl LocalVariablesExample of ILocalVariablesExample {
+        #[external(v0)]
         fn do_something(self: @ContractState, value: u32) -> u32 {
             // This variable is local to the current block. It can't be accessed once it goes out of scope.
             let increment = 10;

--- a/listings/ch00-getting-started/variables/src/storage_variables.cairo
+++ b/listings/ch00-getting-started/variables/src/storage_variables.cairo
@@ -8,15 +8,17 @@ mod StorageVariablesExample {
         value: u32
     }
 
+    #[abi(per_item)]
     #[generate_trait]
-    #[external(v0)]
     impl StorageVariablesExample of IStorageVariableExample {
         // Write to storage variables by sending a transaction that calls an external function
+        #[external(v0)]
         fn set(ref self: ContractState, value: u32) {
             self.value.write(value);
         }
 
         // Read from storage variables without sending transactions
+        #[external(v0)]
         fn get(ref self: ContractState) -> u32 {
             self.value.read()
         }

--- a/listings/ch00-getting-started/visibility/src/visibility.cairo
+++ b/listings/ch00-getting-started/visibility/src/visibility.cairo
@@ -1,3 +1,9 @@
+#[starknet::interface]
+trait IExampleContract<TContractState> {
+    fn set(ref self: TContractState, value: u32);
+    fn get(self: @TContractState) -> u32;
+}
+
 #[starknet::contract]
 mod ExampleContract {
     #[storage]
@@ -6,11 +12,10 @@ mod ExampleContract {
     }
 
 
-    // The `external(v0)` attribute indicates that all the functions in this implementation can be called externally.
+    // The `abi(embed_v0)` attribute indicates that all the functions in this implementation can be called externally.
     // Omitting this attribute would make all the functions in this implementation internal.
-    #[external(v0)]
-    #[generate_trait]
-    impl ExampleContract of IExampleContract {
+    #[abi(embed_v0)]
+    impl ExampleContract of super::IExampleContract<ContractState> {
         // The `set` function can be called externally because it is written inside an implementation marked as `#[external]`.
         // It can modify the contract's state as it is passed as a reference.
         fn set(ref self: ContractState, value: u32) {
@@ -29,7 +34,7 @@ mod ExampleContract {
     // We name the trait `PrivateFunctionsTrait` to indicate that it is an internal trait allowing us to call internal functions.
     #[generate_trait]
     impl PrivateFunctions of PrivateFunctionsTrait {
-        // The `_read_value` function is outside the implementation that is marked as `#[external(v0)]`, so it's an _internal_ function
+        // The `_read_value` function is outside the implementation that is marked as `#[abi(embed_v0)]`, so it's an _internal_ function
         // and can only be called from within the contract.
         // It can modify the contract's state as it is passed as a reference.
         fn _read_value(self: @ContractState) -> u32 {

--- a/listings/ch01-applications/simple_vault/src/simple_vault.cairo
+++ b/listings/ch01-applications/simple_vault/src/simple_vault.cairo
@@ -17,6 +17,12 @@ trait IERC20<TContractState> {
     fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
 }
 
+#[starknet::interface]
+trait ISimpleVault<TContractState> {
+    fn deposit(ref self: TContractState, amount: u256);
+    fn withdraw(ref self: TContractState, shares: u256);
+}
+
 #[starknet::contract]
 mod SimpleVault {
     use super::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -46,9 +52,8 @@ mod SimpleVault {
         }
     }
 
-    #[external(v0)]
-    #[generate_trait]
-    impl SimpleVault of ISimpleVault {
+    #[abi(embed_v0)]
+    impl SimpleVault of super::ISimpleVault<ContractState> {
         fn deposit(ref self: ContractState, amount: u256) {
             // a = amount
             // B = balance of token before deposit

--- a/listings/ch01-applications/upgradeable_contract/src/upgradeable_contract_v0.cairo
+++ b/listings/ch01-applications/upgradeable_contract/src/upgradeable_contract_v0.cairo
@@ -1,3 +1,11 @@
+use starknet::class_hash::ClassHash;
+
+#[starknet::interface]
+trait IUpgradeableContract<TContractState> {
+    fn upgrade(ref self: TContractState, impl_hash: ClassHash);
+    fn version(self: @TContractState) -> u8;
+}
+
 #[starknet::contract]
 mod UpgradeableContract_V0 {
     use starknet::class_hash::ClassHash;
@@ -18,9 +26,8 @@ mod UpgradeableContract_V0 {
         implementation: ClassHash
     }
 
-    #[generate_trait]
-    #[external(v0)]
-    impl UpgradeableContract of IUpgradeableContract {
+    #[abi(embed_v0)]
+    impl UpgradeableContract of super::IUpgradeableContract<ContractState> {
         fn upgrade(ref self: ContractState, impl_hash: ClassHash) {
             assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
             starknet::replace_class_syscall(impl_hash).unwrap_syscall();

--- a/listings/ch01-applications/upgradeable_contract/src/upgradeable_contract_v1.cairo
+++ b/listings/ch01-applications/upgradeable_contract/src/upgradeable_contract_v1.cairo
@@ -1,3 +1,11 @@
+use starknet::class_hash::ClassHash;
+
+#[starknet::interface]
+trait IUpgradeableContract<TContractState> {
+    fn upgrade(ref self: TContractState, impl_hash: ClassHash);
+    fn version(self: @TContractState) -> u8;
+}
+
 #[starknet::contract]
 mod UpgradeableContract_V1 {
     use starknet::class_hash::ClassHash;
@@ -18,9 +26,8 @@ mod UpgradeableContract_V1 {
         implementation: ClassHash
     }
 
-    #[generate_trait]
-    #[external(v0)]
-    impl UpgradeableContract of IUpgradeableContract {
+    #[abi(embed_v0)]
+    impl UpgradeableContract of super::IUpgradeableContract<ContractState> {
         fn upgrade(ref self: ContractState, impl_hash: ClassHash) {
             assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
             starknet::replace_class_syscall(impl_hash).unwrap_syscall();

--- a/listings/ch02-advanced-concepts/store_using_packing/src/contract.cairo
+++ b/listings/ch02-advanced-concepts/store_using_packing/src/contract.cairo
@@ -41,7 +41,7 @@ mod TimeContract {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TimeContract of super::ITime<ContractState> {
         fn set(ref self: ContractState, value: Time) {
             // This will call the pack method of the TimePackable trait

--- a/listings/ch02-advanced-concepts/storing_arrays/src/contract.cairo
+++ b/listings/ch02-advanced-concepts/storing_arrays/src/contract.cairo
@@ -68,6 +68,12 @@ impl StoreFelt252Array of Store<Array<felt252>> {
 // ANCHOR_END: StorageAccessImpl
 
 // ANCHOR: StoreArrayContract
+#[starknet::interface]
+trait IStoreArrayContract<TContractState> {
+    fn store_array(ref self: TContractState, arr: Array<felt252>);
+    fn read_array(self: @TContractState) -> Array<felt252>;
+}
+
 #[starknet::contract]
 mod StoreArrayContract {
     use super::StoreFelt252Array;
@@ -77,9 +83,8 @@ mod StoreArrayContract {
         arr: Array<felt252>
     }
 
-    #[generate_trait]
-    #[external(v0)]
-    impl StoreArrayImpl of IStoreArrayContract {
+    #[abi(embed_v0)]
+    impl StoreArrayImpl of super::IStoreArrayContract<ContractState> {
         fn store_array(ref self: ContractState, arr: Array<felt252>) {
             self.arr.write(arr);
         }
@@ -91,8 +96,4 @@ mod StoreArrayContract {
 }
 // ANCHOR_END: StoreArrayContract
 
-#[starknet::interface]
-trait IStoreArrayContract<TContractState> {
-    fn store_array(ref self: TContractState, array: Array<felt252>);
-    fn read_array(self: @TContractState) -> Array<felt252>;
-}
+

--- a/listings/ch02-advanced-concepts/struct_as_mapping_key/Scarb.toml
+++ b/listings/ch02-advanced-concepts/struct_as_mapping_key/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
-name = "src"
+name = "struct_as_mapping_key"
 version = "0.1.0"
 
 [dependencies]

--- a/listings/ch02-advanced-concepts/struct_as_mapping_key/src/contract.cairo
+++ b/listings/ch02-advanced-concepts/struct_as_mapping_key/src/contract.cairo
@@ -1,22 +1,28 @@
+#[derive(Copy, Drop, Serde, Hash)]
+struct Pet {
+    name: felt252,
+    age: u8,
+    owner: felt252,
+}
+
+#[starknet::interface]
+trait IPetRegistry<TContractState> {
+    fn register_pet(ref self: TContractState, key: Pet, timestamp: u64);
+    fn get_registration_date(self: @TContractState, key: Pet) -> u64;
+}
+
 #[starknet::contract]
 mod PetRegistry {
     use hash::{HashStateTrait, Hash};
+    use super::Pet;
 
     #[storage]
     struct Storage {
         registration_time: LegacyMap::<Pet, u64>,
     }
 
-    #[derive(Copy, Drop, Serde, Hash)]
-    struct Pet {
-        name: felt252,
-        age: u8,
-        owner: felt252,
-    }
-
-    #[external(v0)]
-    #[generate_trait]
-    impl PetRegistry of PetRegistryTrait {
+    #[abi(embed_v0)]
+    impl PetRegistry of super::IPetRegistry<ContractState> {
         fn register_pet(ref self: ContractState, key: Pet, timestamp: u64) {
             self.registration_time.write(key, timestamp);
         }

--- a/listings/ch02-advanced-concepts/struct_as_mapping_key/src/test.cairo
+++ b/listings/ch02-advanced-concepts/struct_as_mapping_key/src/test.cairo
@@ -1,5 +1,5 @@
 mod tests {
-    use src::contract::PetRegistry;
+    use struct_as_mapping_key::contract::PetRegistry;
     use PetRegistry::Pet;
     use starknet::deploy_syscall;
     use starknet::class_hash::Felt252TryIntoClassHash;

--- a/listings/ch02-advanced-concepts/write_to_any_slot/src/contract.cairo
+++ b/listings/ch02-advanced-concepts/write_to_any_slot/src/contract.cairo
@@ -1,3 +1,9 @@
+#[starknet::interface]
+trait IWriteToAnySlots<TContractState> {
+    fn write_slot(ref self: TContractState, value: u32);
+    fn read_slot(self: @TContractState) -> u32;
+}
+
 #[starknet::contract]
 mod WriteToAnySlot {
     use starknet::syscalls::{storage_read_syscall, storage_write_syscall};
@@ -11,9 +17,8 @@ mod WriteToAnySlot {
 
     const SLOT_NAME: felt252 = 'test_slot';
 
-    #[generate_trait]
-    #[external(v0)]
-    impl WriteToAnySlot of IWriteToAnySlot {
+    #[abi(embed_v0)]
+    impl WriteToAnySlot of super::IWriteToAnySlots<ContractState> {
         fn write_slot(ref self: ContractState, value: u32) {
             storage_write_syscall(0, get_address_from_name(SLOT_NAME), value.into());
         }

--- a/src/ch00/basics/variables.md
+++ b/src/ch00/basics/variables.md
@@ -29,7 +29,7 @@ Visit contract on [Voyager](https://goerli.voyager.online/contract/0x015B3a10F96
 
 Storage variables are persistent data stored on the blockchain. They can be accessed from one execution to another, allowing the contract to remember and update information over time.
 
-To write or update a storage variable, you need to interact with the contract through an `#[external]` entrypoint by sending a transaction.
+To write or update a storage variable, you need to interact with the contract through an external entrypoint by sending a transaction.
 
 On the other hand, you can read state variables, for free, without any transaction, simply by interacting with a node.
 

--- a/src/ch00/basics/visibility-mutability.md
+++ b/src/ch00/basics/visibility-mutability.md
@@ -7,7 +7,7 @@ There are two types of functions in Starknet contracts:
 - Functions that are accessible externally and can be called by anyone.
 - Functions that are only accessible internally and can only be called by other functions in the contract.
 
-These functions are also typically divided into two different implementations blocks. The first `impl` block for externally accessible functions is explicitly annotated with an `#[external(v0)]` attribute. This indicates that all the functions inside this block can be called either as a transaction or as a view function. The second `impl` block for internally accessible functions is not annotated with any attribute, which means that all the functions inside this block are private by default.
+These functions are also typically divided into two different implementations blocks. The first `impl` block for externally accessible functions is explicitly annotated with an `#[abi(embed_v0)]` attribute. This indicates that all the functions inside this block can be called either as a transaction or as a view function. The second `impl` block for internally accessible functions is not annotated with any attribute, which means that all the functions inside this block are private by default.
 
 ## State Mutability
 


### PR DESCRIPTION
**Issue(s):**  Close #91

### Description

Remove `#[external(v0)]` usage in implementation blocks of contracts in favor of `#[abi(embed_v0)]` or `#[abi(per_item)]`. These last two need to be explained (hence #97).

### Checklist

- [x] **CI Verifier:** Run `cairo_programs_verifier` successfully
