### PR TITLE
Test storing custom types

### DIFF
--- a/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
@@ -1,32 +1,34 @@
 #[starknet::interface]
 trait IStoringCustomType<TContractState> {
-    fn set_person(ref self: TContractState);
-    fn get_person(self: @TContractState);
+    fn set_person(ref self: TContractState, person: Person);
+    fn get_person(self: @TContractState) -> Person;
+}
+
+// Deriving the starknet::Store trait
+// allows us to store the `Person` struct in the contract's storage.
+#[derive(Drop, Serde, Copy, starknet::Store)]
+struct Person {
+    age: u8,
+    name: felt252
 }
 
 #[starknet::contract]
 mod StoringCustomType {
+    use super::Person;
+
     #[storage]
     struct Storage {
         person: Person
     }
 
-    // Deriving the starknet::Store trait
-    // allows us to store the `Person` struct in the contract's storage.
-    #[derive(Drop, starknet::Store)]
-    struct Person {
-        age: u8,
-        name: felt252
-    }
-
     #[abi(embed_v0)]
     impl StoringCustomType of super::IStoringCustomType<ContractState> {
-        fn set_person(ref self: ContractState) {
-            self.person.write(Person { age: 10, name: 'Joe' });
+        fn set_person(ref self: ContractState, person: Person) {
+            self.person.write(person);
         }
 
-        fn get_person(self: @ContractState) {
-            self.person.read();
+        fn get_person(self: @ContractState) -> Person {
+            self.person.read()
         }
     }
 }

--- a/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
@@ -1,7 +1,6 @@
 #[starknet::interface]
 trait IStoringCustomType<TContractState> {
     fn set_person(ref self: TContractState, person: Person);
-    fn get_person(self: @TContractState) -> Person;
 }
 
 // Deriving the starknet::Store trait
@@ -25,10 +24,6 @@ mod StoringCustomType {
     impl StoringCustomType of super::IStoringCustomType<ContractState> {
         fn set_person(ref self: ContractState, person: Person) {
             self.person.write(person);
-        }
-
-        fn get_person(self: @ContractState) -> Person {
-            self.person.read()
         }
     }
 }

--- a/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
@@ -1,7 +1,7 @@
 #[starknet::interface]
 trait IStoringCustomType<TContractState> {
     fn set_person(ref self: TContractState);
-    fn get_person(ref self: TContractState);
+    fn get_person(self: @TContractState);
 }
 
 #[starknet::contract]
@@ -21,12 +21,14 @@ mod StoringCustomType {
 
     #[abi(per_item)]
     #[external(v0)]
-    fn set_person(ref self: ContractState) {
-        self.person.write(Person { age: 10, name: 'Joe' });
-    }
+    impl StoringCustomType of super::IStoringCustomType<ContractState> {
+        fn set_person(ref self: ContractState) {
+            self.person.write(Person { age: 10, name: 'Joe' });
+        }
 
-    #[external(v0)]
-    fn get_person(self: @ContractState) {
-        self.person.read();
+        #[external(v0)]
+        fn get_person(self: @ContractState) {
+            self.person.read();
+        }
     }
 }

--- a/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
@@ -19,14 +19,12 @@ mod StoringCustomType {
         name: felt252
     }
 
-    #[abi(per_item)]
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl StoringCustomType of super::IStoringCustomType<ContractState> {
         fn set_person(ref self: ContractState) {
             self.person.write(Person { age: 10, name: 'Joe' });
         }
 
-        #[external(v0)]
         fn get_person(self: @ContractState) {
             self.person.read();
         }

--- a/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/contract.cairo
@@ -1,3 +1,9 @@
+#[starknet::interface]
+trait IStoringCustomType<TContractState> {
+    fn set_person(ref self: TContractState);
+    fn get_person(ref self: TContractState);
+}
+
 #[starknet::contract]
 mod StoringCustomType {
     #[storage]
@@ -14,16 +20,13 @@ mod StoringCustomType {
     }
 
     #[abi(per_item)]
-    #[generate_trait]
-    impl StoringCustomType of IStoringCustomType {
-        #[external(v0)]
-        fn set_person(ref self: ContractState) {
-            self.person.write(Person { age: 10, name: 'Joe' });
-        }
+    #[external(v0)]
+    fn set_person(ref self: ContractState) {
+        self.person.write(Person { age: 10, name: 'Joe' });
+    }
 
-        #[external(v0)]
-        fn get_person(self: @ContractState) {
-            self.person.read();
-        }
+    #[external(v0)]
+    fn get_person(self: @ContractState) {
+        self.person.read();
     }
 }

--- a/listings/ch00-getting-started/storing_custom_types/src/tests.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/tests.cairo
@@ -1,5 +1,4 @@
 // The purpose of these tests is to demonstrate the capability to store custom types in the contract's state.
-// However, because Serde trait is not implemented for the custom type, we can't use custom types as parameters or return values.
 
 mod tests {
     use storing_custom_types::{

--- a/listings/ch00-getting-started/storing_custom_types/src/tests.cairo
+++ b/listings/ch00-getting-started/storing_custom_types/src/tests.cairo
@@ -1,2 +1,42 @@
-mod tests { // TODO
+// The purpose of these tests is to demonstrate the capability to store custom types in the contract's state.
+// However, because Serde trait is not implemented for the custom type, we can't use custom types as parameters or return values.
+
+mod tests {
+    use storing_custom_types::contract::IStoringCustomTypeDispatcherTrait;
+    use storing_custom_types::contract::{
+        StoringCustomType, IStoringCustomTypeDispatcher, StoringCustomType::Person
+    };
+    use core::result::ResultTrait;
+    use starknet::{deploy_syscall, ContractAddress};
+    use starknet::class_hash::Felt252TryIntoClassHash;
+
+    fn deploy() -> IStoringCustomTypeDispatcher {
+        let calldata: Array<felt252> = array![];
+        let (address0, _) = deploy_syscall(
+            StoringCustomType::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false
+        )
+            .unwrap();
+        IStoringCustomTypeDispatcher { contract_address: address0 }
+    }
+
+    #[test]
+    #[available_gas(2000000000)]
+    fn should_deploy() {
+        let init_value = 10;
+        let contract = deploy();
+    }
+
+    #[test]
+    #[available_gas(2000000000)]
+    fn can_call_set_person() {
+        let contract = deploy();
+        let received_person = contract.set_person();
+    }
+
+    #[test]
+    #[available_gas(2000000000)]
+    fn can_call_get_person() {
+        let contract = deploy();
+        contract.get_person();
+    }
 }


### PR DESCRIPTION
**Issue:** related to #70 

### Description

This PR introduces unit tests for `storing_custom_type`. The main objective of these tests is to demonstrate the storage of custom types within the contract's storage system. Currently, the custom type used does not implement the Serde trait. As a result, we cannot retrieve a return value from the `get_person` function, which limits its utility. I am considering removing this function due to its limited functionality. 