### PR TITLE
fix: remove useless contract part of cheatsheet

### DIFF
--- a/listings/ch00-getting-started/cairo_cheatsheet/Scarb.lock
+++ b/listings/ch00-getting-started/cairo_cheatsheet/Scarb.lock
@@ -2,13 +2,5 @@
 version = 1
 
 [[package]]
-name = "alexandria_storage"
-version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=ae1d514#ae1d5149ff601a7ac5b39edc867d33ebd83d7f4f"
-
-[[package]]
 name = "cairo_cheatsheet"
 version = "0.1.0"
-dependencies = [
- "alexandria_storage",
-]

--- a/listings/ch00-getting-started/cairo_cheatsheet/Scarb.toml
+++ b/listings/ch00-getting-started/cairo_cheatsheet/Scarb.toml
@@ -4,6 +4,5 @@ version = "0.1.0"
 
 [dependencies]
 starknet = ">=2.3.0"
-alexandria_storage = { git = "https://github.com/keep-starknet-strange/alexandria.git",  rev="ae1d514"}
 
 [[target.starknet-contract]]

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/array_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/array_example.cairo
@@ -1,32 +1,17 @@
-#[starknet::interface]
-trait IArrayExample<TContractState> {
-    fn createarray(self: @TContractState, num_one: u32, num_two: u32, num_three: u32) -> bool;
-}
+fn array() -> bool {
+    let mut arr = ArrayTrait::<u32>::new();
+    arr.append(10);
+    arr.append(20);
+    arr.append(30);
 
-#[starknet::contract]
-mod ArrayExample {
-    #[storage]
-    struct Storage {}
+    assert(arr.len() == 3, 'array length should be 3');
 
+    let first_value = arr.pop_front().unwrap();
+    assert(first_value == 10, 'first value should match');
 
-    #[abi(embed_v0)]
-    impl External of super::IArrayExample<ContractState> {
-        fn createarray(self: @ContractState, num_one: u32, num_two: u32, num_three: u32) -> bool {
-            let mut arr = ArrayTrait::<u32>::new();
-            arr.append(num_one);
-            arr.append(num_two);
-            arr.append(num_three);
+    let second_value = *arr.at(0);
+    assert(second_value == 20, 'second value should match');
 
-            assert(arr.len() == 3, 'array length should be 3');
-
-            let first_value = arr.pop_front().unwrap();
-            assert(first_value == num_one, 'first value should match');
-
-            let second_value = *arr.at(0);
-            assert(second_value == num_two, 'second value should match');
-
-            //Returns true if an array is empty, then false if it isn't.
-            arr.is_empty()
-        }
-    }
+    // Returns true if an array is empty, then false if it isn't.
+    arr.is_empty()
 }

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/felt_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/felt_example.cairo
@@ -1,30 +1,8 @@
-use starknet::ContractAddress;
-#[starknet::interface]
-trait IFelt252Example<TContractState> {
-    fn store_name(ref self: TContractState, name: felt252) -> felt252;
-    fn view_name(self: @TContractState, address: ContractAddress) -> felt252;
-}
+fn felt() {
+    // ANCHOR: sheet
+    let felt: felt252 = 100;
+    let felt_as_str = 'Hello Starknet!';
 
-#[starknet::contract]
-mod Felt252Example {
-    use starknet::{ContractAddress, get_caller_address};
-
-    #[storage]
-    struct Storage {
-        user_name: LegacyMap::<ContractAddress, felt252>,
-    }
-
-    #[abi(embed_v0)]
-    impl External of super::IFelt252Example<ContractState> {
-        fn store_name(ref self: ContractState, name: felt252) -> felt252 {
-            self.user_name.write(get_caller_address(), name);
-
-            let welcome_msg: felt252 = 'Welcome to StarknetByExample';
-            welcome_msg
-        }
-
-        fn view_name(self: @ContractState, address: ContractAddress) -> felt252 {
-            self.user_name.read(address)
-        }
-    }
+    let felt = felt + felt_as_str;
+// ANCHOR_END: sheet
 }

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/loop_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/loop_example.cairo
@@ -1,29 +1,18 @@
-#[starknet::interface]
-trait ILoopExample<TContractState> {
-    fn gather_evens(ref self: TContractState, maxLimit: u32) -> Array<u32>;
-}
+fn do_loop() {
+    // ANCHOR: sheet
+    let mut arr = ArrayTrait::new();
 
-#[starknet::contract]
-mod LoopExample {
-    #[storage]
-    struct Storage {}
+    // Same as ~ while (i < 10) arr.append(i++);
+    let mut i: u32 = 0;
+    let limit = 10;
+    loop {
+        if i == limit {
+            break;
+        };
 
-    #[abi(embed_v0)]
-    impl External of super::ILoopExample<ContractState> {
-        fn gather_evens(ref self: ContractState, maxLimit: u32) -> Array<u32> {
-            let mut i: u32 = 0;
-            let mut arr = ArrayTrait::new();
-            loop {
-                if i == maxLimit {
-                    break;
-                };
-                if (i % 2 == 0) {
-                    arr.append(i);
-                }
-                i += 1;
-            };
+        arr.append(i);
 
-            return arr;
-        }
-    }
+        i += 1;
+    };
+// ANCHOR_END: sheet
 }

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/match_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/match_example.cairo
@@ -1,11 +1,3 @@
-#[starknet::interface]
-trait IMatchExample<TContractState> {
-    fn value_in_cents(self: @TContractState, coin: Coin) -> felt252;
-    fn specified_colour(self: @TContractState, colour: Colour) -> felt252;
-    fn quiz(self: @TContractState, num: felt252) -> felt252;
-}
-
-
 #[derive(Drop, Serde)]
 enum Colour {
     Red,
@@ -23,47 +15,36 @@ enum Coin {
     Quarter,
 }
 
-
-#[starknet::contract]
-mod MatchExample {
-    use super::{Colour, Coin};
-    #[storage]
-    struct Storage {}
-
-    #[abi(embed_v0)]
-    impl External of super::IMatchExample<ContractState> {
-        fn value_in_cents(self: @ContractState, coin: Coin) -> felt252 {
-            match coin {
-                Coin::Penny => 1,
-                Coin::Nickel => 5,
-                Coin::Dime => 10,
-                Coin::Quarter => 25,
-            }
-        }
-
-        fn specified_colour(self: @ContractState, colour: Colour) -> felt252 {
-            let mut response: felt252 = '';
-
-            match colour {
-                Colour::Red => { response = 'You passed in Red'; },
-                Colour::Blue => { response = 'You passed in Blue'; },
-                Colour::Green => { response = 'You passed in Green'; },
-                Colour::Orange => { response = 'You passed in Orange'; },
-                Colour::Black => { response = 'You passed in Black'; },
-            };
-
-            response
-        }
-
-        fn quiz(self: @ContractState, num: felt252) -> felt252 {
-            let mut response: felt252 = '';
-
-            match num {
-                0 => { response = 'You failed' },
-                _ => { response = 'You Passed' },
-            };
-
-            response
-        }
+fn value_in_cents(coin: Coin) -> felt252 {
+    match coin {
+        Coin::Penny => 1,
+        Coin::Nickel => 5,
+        Coin::Dime => 10,
+        Coin::Quarter => 25,
     }
+}
+
+fn specified_colour(colour: Colour) -> felt252 {
+    let mut response: felt252 = '';
+
+    match colour {
+        Colour::Red => { response = 'You passed in Red'; },
+        Colour::Blue => { response = 'You passed in Blue'; },
+        Colour::Green => { response = 'You passed in Green'; },
+        Colour::Orange => { response = 'You passed in Orange'; },
+        Colour::Black => { response = 'You passed in Black'; },
+    };
+
+    response
+}
+
+fn quiz(num: felt252) -> felt252 {
+    let mut response: felt252 = '';
+
+    match num {
+        0 => { response = 'You failed' },
+        _ => { response = 'You Passed' },
+    };
+
+    response
 }

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/struct_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/struct_example.cairo
@@ -1,38 +1,6 @@
-use starknet::ContractAddress;
-
-#[starknet::interface]
-trait IStructExample<TContractState> {
-    fn store_struct(ref self: TContractState, age: u8);
-    fn read_struct(self: @TContractState) -> (ContractAddress, u8);
-}
-
-#[starknet::contract]
-mod StructExample {
-    use starknet::{ContractAddress, get_caller_address};
-
-    #[storage]
-    struct Storage {
-        user_data: Data
-    }
-
-    #[derive(Drop, starknet::Store)]
-    struct Data {
-        address: ContractAddress,
-        age: u8
-    }
-
-    #[abi(embed_v0)]
-    impl StoreStructImpl of super::IStructExample<ContractState> {
-        fn store_struct(ref self: ContractState, age: u8) {
-            let new_struct = Data { address: get_caller_address(), age: age };
-            self.user_data.write(new_struct);
-        }
-
-        fn read_struct(self: @ContractState) -> (ContractAddress, u8) {
-            let last_user = self.user_data.read();
-            let add = last_user.address;
-            let age = last_user.age;
-            (add, age)
-        }
-    }
+// With Store, you can store Data's structs in the storage part of contracts.
+#[derive(Drop, starknet::Store)]
+struct Data {
+    address: starknet::ContractAddress,
+    age: u8
 }

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/tuple_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/tuple_example.cairo
@@ -1,31 +1,13 @@
-use starknet::ContractAddress;
+fn tuple() {
+    // ANCHOR: sheet
+    let address = "0x000";
+    let age = 20;
+    let active = true;
 
-#[starknet::interface]
-trait ITupleExample<TContractState> {
-    fn store_tuple(self: @TContractState, address: ContractAddress, age: u64, active: bool);
-    fn read_tuple(self: @TContractState) -> (ContractAddress, u64, bool);
-}
+    // Create tuple
+    let user_tuple = (address, age, active);
 
-#[starknet::contract]
-mod TupleExample {
-    use starknet::{ContractAddress, get_caller_address};
-
-    #[storage]
-    struct Storage {
-        user_data: (ContractAddress, u64, bool)
-    }
-
-    #[abi(embed_v0)]
-    impl TupleExampleImpl of super::ITupleExample<ContractState> {
-        fn store_tuple(ref self: ContractState, address: ContractAddress, age: u64, active: bool) {
-            let user_tuple = (address, age, active);
-            self.user_data.write(user_tuple);
-        }
-
-        fn read_tuple(self: @ContractState) -> (ContractAddress, u64, bool) {
-            let stored_tuple = self.user_data.read();
-            let (address, age, active) = stored_tuple;
-            (address, age, active)
-        }
-    }
+    // Access tuple
+    let (address, age, active) = stored_tuple;
+// ANCHOR_END: sheet
 }

--- a/listings/ch00-getting-started/cairo_cheatsheet/src/type_casting_example.cairo
+++ b/listings/ch00-getting-started/cairo_cheatsheet/src/type_casting_example.cairo
@@ -1,39 +1,27 @@
-use starknet::ContractAddress;
+fn type_casting() {
+    // ANCHOR: sheet
+    let a_number: u32 = 15;
+    let my_felt252 = 15;
 
-#[starknet::interface]
-trait ITypecastingExample<TContractState> {
-    fn type_casting(self: @TContractState, rand_number: u32);
-}
-#[starknet::contract]
-mod TypecastingExample {
-    #[storage]
-    struct Storage {}
+    // Since a u32 might not fit in a u8 and a u16, we need to use try_into,
+    // then unwrap the Option<T> type thats returned.
+    let new_u8: u8 = a_number.try_into().unwrap();
+    let new_u16: u16 = a_number.try_into().unwrap();
 
-    #[abi(embed_v0)]
-    impl External of super::ITypecastingExample<ContractState> {
-        fn type_casting(self: @ContractState, rand_number: u32) {
-            let my_felt252 = 15;
+    // since new_u32 is the of the same type (u32) as rand_number, we can directly assign them,
+    // or use the .into() method.
+    let new_u32: u32 = a_number;
 
-            // Since a u32 might not fit in a u8 and a u16, we need to use try_into,
-            // then unwrap the Option<T> type thats returned.
-            let new_u8: u8 = rand_number.try_into().unwrap();
-            let new_u16: u16 = rand_number.try_into().unwrap();
+    // When typecasting from a smaller size to an equal or larger size we use the .into() method.
+    // Note: u64 and u128 are larger than u32, so a u32 type will always fit into them.
+    let new_u64: u64 = a_number.into();
+    let new_u128: u128 = a_number.into();
 
-            // since new_u32 is the of the same type (u32) as rand_number, we can directly assign them,
-            // or use the .into() method.
-            let new_u32: u32 = rand_number;
+    // Since a felt252 is smaller than a u256, we can use the into() method
+    let new_u256: u256 = my_felt252.into();
+    let new_felt252: felt252 = new_u16.into();
 
-            // When typecasting from a smaller size to an equal or larger size we use the .into() method.
-            // Note: u64 and u128 are larger than u32, so a u32 type will always fit into them.
-            let new_u64: u64 = rand_number.into();
-            let new_u128: u128 = rand_number.into();
-
-            // Since a felt252 is smaller than a u256, we can use the into() method
-            let new_u256: u256 = my_felt252.into();
-            let new_felt252: felt252 = new_u16.into();
-
-            //note a usize is smaller than a felt so we use the try_into
-            let new_usize: usize = my_felt252.try_into().unwrap();
-        }
-    }
+    //note a usize is smaller than a felt so we use the try_into
+    let new_usize: usize = my_felt252.try_into().unwrap();
+// ANCHOR_END: sheet
 }

--- a/src/ch00/cairo_cheatsheet/felt.md
+++ b/src/ch00/cairo_cheatsheet/felt.md
@@ -6,5 +6,5 @@ Felt252 can also be used to store short-string representations with a maximum le
 For example:
 
 ```rust
-{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/felt_example.cairo}}
+{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/felt_example.cairo:sheet}}
 ```

--- a/src/ch00/cairo_cheatsheet/loop.md
+++ b/src/ch00/cairo_cheatsheet/loop.md
@@ -4,5 +4,5 @@ A loop specifies a block of code that will run repetitively until a halting cond
 For example:
 
 ```rust
-{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/loop_example.cairo}}
+{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/loop_example.cairo:sheet}}
 ```

--- a/src/ch00/cairo_cheatsheet/tuples.md
+++ b/src/ch00/cairo_cheatsheet/tuples.md
@@ -4,5 +4,5 @@ Tuples is a data type to group a fixed number of items of potentially different 
 For example:
 
 ```rust
-{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/tuple_example.cairo}}
+{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/tuple_example.cairo:sheet}}
 ```

--- a/src/ch00/cairo_cheatsheet/type_casting.md
+++ b/src/ch00/cairo_cheatsheet/type_casting.md
@@ -5,5 +5,5 @@ Cairo supports the conversion from one scalar types to another by using the into
 For example:
 
 ```rust
-{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/type_casting_example.cairo}}
+{{#include ../../../listings/ch00-getting-started/cairo_cheatsheet/src/type_casting_example.cairo:sheet}}
 ```


### PR DESCRIPTION
**Issue(s):** related to #102

### Description

As theses examples are more focused on Cairo syntax, we can remove the contract code when it's not usefull.

### Checklist

- [x] **CI Verifier:** Run `cairo_programs_verifier` successfully
