### PR TITLE
fix: update outdated links to external resources

### DIFF
--- a/src/ch00/basics/mappings.md
+++ b/src/ch00/basics/mappings.md
@@ -8,7 +8,7 @@ Some additional notes:
 
 - More complex key-value mappings are possible, for example we could use `LegacyMap::<(ContractAddress, ContractAddress), felt252>` to create an allowance on an ERC20 token contract.
 
-- In mappings, the address of the value at key `k_1,...,k_n` is `h(...h(h(sn_keccak(variable_name),k_1),k_2),...,k_n)` where `ℎ` is the Pedersen hash and the final value is taken `mod2251−256`. You can learn more about the contract storage layout in the [Starknet Documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-storage/#storage_variables)
+- In mappings, the address of the value at key `k_1,...,k_n` is `h(...h(h(sn_keccak(variable_name),k_1),k_2),...,k_n)` where `ℎ` is the Pedersen hash and the final value is taken `mod2251−256`. You can learn more about the contract storage layout in the [Starknet Documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-storage/#storage_variables)
 
 ```rust
 {{#include ../../../listings/getting-started/mappings/src/mappings.cairo}}

--- a/src/ch00/testing/contract-testing.md
+++ b/src/ch00/testing/contract-testing.md
@@ -44,7 +44,7 @@ You may also need the `info` module from the corelib, which allows you to access
 
 
 You can found the full list of functions in the [Starknet Corelib repo](https://github.com/starkware-libs/cairo/tree/main/corelib/src/starknet).
-You can also find a detailled explaination of testing in cairo in the [Cairo book - Chapter 8](https://book.cairo-lang.org/ch08-01-how-to-write-tests.html).
+You can also find a detailled explaination of testing in cairo in the [Cairo book - Chapter 8](https://book.cairo-lang.org/ch09-01-how-to-write-tests.html).
 
 ## Starknet Foundry
 

--- a/src/ch00/testing/contract-testing.md
+++ b/src/ch00/testing/contract-testing.md
@@ -44,7 +44,7 @@ You may also need the `info` module from the corelib, which allows you to access
 
 
 You can found the full list of functions in the [Starknet Corelib repo](https://github.com/starkware-libs/cairo/tree/main/corelib/src/starknet).
-You can also find a detailled explaination of testing in cairo in the [Cairo book - Chapter 8](https://book.cairo-lang.org/ch09-01-how-to-write-tests.html).
+You can also find a detailled explaination of testing in cairo in the [Cairo book - Chapter 9](https://book.cairo-lang.org/ch09-01-how-to-write-tests.html).
 
 ## Starknet Foundry
 


### PR DESCRIPTION
### Description

Hello,
I'm replacing two outdated links to external resources with working versions. One of them is to Starknet docs and the second to Cairo lang book.

Didn't do anything from checklist below, as the changes are only in documentation.

### Checklist

- [ ] **CI Verifier:** Run `cairo_programs_verifier` successfully
- [ ] **Contract Tests:** Added tests to cover the changes
- [ ] **Remix Link:** Added a link to open the contract in Remix
- [ ] **Deployed Contract (Optional):** If possible, include a Voyager link to a deployed contract on Goerli
