### PR TITLE
Add link to NFT Dutch Auction chapter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -56,6 +56,7 @@ Summary
 - [Upgradeable Contract](./applications/upgradeable_contract.md)
 - [Defi Vault](./applications/simple_vault.md)
 - [ERC20 Token](./applications/erc20.md)
+- [NFT Dutch Auction](./applications/nft_dutch_auction.md)
 - [Constant Product AMM](./applications/constant-product-amm.md)
 - [TimeLock](./applications/timelock.md)
 - [Staking](./applications/staking.md)


### PR DESCRIPTION
### Description

I added the link to NFT Dutch Auction chapter that was excluded from SUMMARY.md during this commit [3fbfb60](https://github.com/NethermindEth/StarknetByExample/commit/3fbfb60#diff-a7e3a664e97aa06240065215cf96d786578e4609d0b42fdfe14be434bc97b22fL58)
<img width="655" alt="Untitled" src="https://github.com/user-attachments/assets/0e545135-7eba-42a5-810d-b057cece281f">


### Checklist

- [x] **CI Verifier:** Run `./scripts/cairo_programs_verifier.sh` successfully
- [ ] **Contract Tests:** Added tests to cover the changes
<!-- - [ ] **Remix Link:** Added a link to open the contract in Remix
- [ ] **Deployed Contract (Optional):** If possible, include a Voyager link to a deployed contract on Goerli -->
