### PR TITLE
Minor _Scarb.toml_ refactors

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.8.2
-starknet-foundry 0.30.0
+starknet-foundry 0.31.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.8.2
-starknet-foundry 0.31.0
+starknet-foundry 0.30.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,6 @@ version.workspace = true
 
 [dependencies]
 starknet.workspace = true
-snforge_std.workspace = true
 # Uncomment the following lines if you want to use additional dependencies:
 # OpenZeppelin:
 # openzeppelin.workspace = true
@@ -122,6 +121,7 @@ snforge_std.workspace = true
 
 [dev-dependencies]
 assert_macros.workspace = true
+snforge_std.workspace = true
 
 [scripts]
 test.workspace = true

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -244,15 +244,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.2.0"
+version = "0.31.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:2e4ce3ebe3f49548bd26908391b5d78537a765d827df0d96c32aeb88941d0d67"
+checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
 
 [[package]]
 name = "snforge_std"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:2f3c4846881813ac0f5d1460981249c9f5e2a6831e752beedf9b70975495b4ec"
+checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -244,15 +244,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.31.0"
+version = "0.2.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
+checksum = "sha256:2e4ce3ebe3f49548bd26908391b5d78537a765d827df0d96c32aeb88941d0d67"
 
 [[package]]
 name = "snforge_std"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
+checksum = "sha256:2f3c4846881813ac0f5d1460981249c9f5e2a6831e752beedf9b70975495b4ec"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -15,7 +15,7 @@ test = "$(git rev-parse --show-toplevel)/scripts/test_resolver.sh"
 starknet = "2.8.2"
 cairo_test = "2.8.2"
 assert_macros = "2.8.2" 
-snforge_std = "0.31.0"
+snforge_std = "0.30.0"
 openzeppelin = "0.16.0"
 components = { path = "listings/applications/components" }
 pragma_lib = { git = "https://github.com/astraly-labs/pragma-lib" }

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -15,7 +15,7 @@ test = "$(git rev-parse --show-toplevel)/scripts/test_resolver.sh"
 starknet = "2.8.2"
 cairo_test = "2.8.2"
 assert_macros = "2.8.2" 
-snforge_std = "0.30.0"
+snforge_std = "0.31.0"
 openzeppelin = "0.16.0"
 components = { path = "listings/applications/components" }
 pragma_lib = { git = "https://github.com/astraly-labs/pragma-lib" }

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -27,6 +27,7 @@ homepage = "https://www.nethermind.io/"
 license = "MIT"
 authors = ["julio4", "msaug"]
 version = "0.1.0"
+edition = "2024_07"
 
 [tool]
 snforge.workspace = true

--- a/listings/advanced-concepts/ecdsa_verification/Scarb.toml
+++ b/listings/advanced-concepts/ecdsa_verification/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ecdsa_verification"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/hash_solidity_compatible/Scarb.toml
+++ b/listings/advanced-concepts/hash_solidity_compatible/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash_solidity_compatible"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/hash_trait/Scarb.toml
+++ b/listings/advanced-concepts/hash_trait/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash_trait"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/library_calls/Scarb.toml
+++ b/listings/advanced-concepts/library_calls/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "library_calls"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/simple_account/Scarb.toml
+++ b/listings/advanced-concepts/simple_account/Scarb.toml
@@ -7,9 +7,6 @@ edition.workspace = true
 starknet.workspace = true
 openzeppelin.workspace = true
 
-[dev-dependencies]
-cairo_test.workspace = true
-
 [scripts]
 test.workspace = true
 

--- a/listings/advanced-concepts/simple_account/Scarb.toml
+++ b/listings/advanced-concepts/simple_account/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple_account"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/simple_account/Scarb.toml
+++ b/listings/advanced-concepts/simple_account/Scarb.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 starknet.workspace = true
 openzeppelin.workspace = true
 
+[dev-dependencies]
+cairo_test.workspace = true
+
 [scripts]
 test.workspace = true
 

--- a/listings/advanced-concepts/store_using_packing/Scarb.toml
+++ b/listings/advanced-concepts/store_using_packing/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "store_using_packing"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/struct_as_mapping_key/Scarb.toml
+++ b/listings/advanced-concepts/struct_as_mapping_key/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "struct_as_mapping_key"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/advanced-concepts/write_to_any_slot/Scarb.toml
+++ b/listings/advanced-concepts/write_to_any_slot/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "write_to_any_slot"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/advanced_factory/Scarb.toml
+++ b/listings/applications/advanced_factory/Scarb.toml
@@ -16,5 +16,4 @@ snforge_std.workspace = true
 test.workspace = true
 
 [[target.starknet-contract]]
-casm = true
 build-external-contracts = ["crowdfunding::campaign::Campaign"]

--- a/listings/applications/advanced_factory/Scarb.toml
+++ b/listings/applications/advanced_factory/Scarb.toml
@@ -11,6 +11,7 @@ crowdfunding = { path = "../crowdfunding" }
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
+cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/advanced_factory/Scarb.toml
+++ b/listings/applications/advanced_factory/Scarb.toml
@@ -11,7 +11,6 @@ crowdfunding = { path = "../crowdfunding" }
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
-cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/advanced_factory/Scarb.toml
+++ b/listings/applications/advanced_factory/Scarb.toml
@@ -6,11 +6,11 @@ edition.workspace = true
 [dependencies]
 starknet.workspace = true
 components.workspace = true
-snforge_std.workspace = true
 crowdfunding = { path = "../crowdfunding" }
 
 [dev-dependencies]
 assert_macros.workspace = true
+snforge_std.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/advanced_factory/Scarb.toml
+++ b/listings/applications/advanced_factory/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "advanced_factory"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/coin_flip/Scarb.toml
+++ b/listings/applications/coin_flip/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coin_flip"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [lib]
 

--- a/listings/applications/coin_flip/Scarb.toml
+++ b/listings/applications/coin_flip/Scarb.toml
@@ -11,7 +11,6 @@ pragma_lib.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
-cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/coin_flip/Scarb.toml
+++ b/listings/applications/coin_flip/Scarb.toml
@@ -3,8 +3,6 @@ name = "coin_flip"
 version.workspace = true
 edition.workspace = true
 
-[lib]
-
 [dependencies]
 starknet.workspace = true
 openzeppelin.workspace = true

--- a/listings/applications/coin_flip/Scarb.toml
+++ b/listings/applications/coin_flip/Scarb.toml
@@ -11,6 +11,7 @@ pragma_lib.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
+cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/coin_flip/Scarb.toml
+++ b/listings/applications/coin_flip/Scarb.toml
@@ -9,10 +9,10 @@ edition.workspace = true
 starknet.workspace = true
 openzeppelin.workspace = true
 pragma_lib.workspace = true
-snforge_std.workspace = true
 
 [dev-dependencies]
 assert_macros.workspace = true
+snforge_std.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/components/Scarb.toml
+++ b/listings/applications/components/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "components"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [lib]
 

--- a/listings/applications/components_dependencies/Scarb.toml
+++ b/listings/applications/components_dependencies/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "components_dependencies"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/constant_product_amm/Scarb.toml
+++ b/listings/applications/constant_product_amm/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "constant_product_amm"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/crowdfunding/Scarb.toml
+++ b/listings/applications/crowdfunding/Scarb.toml
@@ -13,6 +13,7 @@ components.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
+cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/crowdfunding/Scarb.toml
+++ b/listings/applications/crowdfunding/Scarb.toml
@@ -13,7 +13,6 @@ components.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
-cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/crowdfunding/Scarb.toml
+++ b/listings/applications/crowdfunding/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crowdfunding"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [lib]
 

--- a/listings/applications/crowdfunding/Scarb.toml
+++ b/listings/applications/crowdfunding/Scarb.toml
@@ -9,10 +9,10 @@ edition.workspace = true
 starknet.workspace = true
 openzeppelin.workspace = true
 components.workspace = true
-snforge_std.workspace = true
 
 [dev-dependencies]
 assert_macros.workspace = true
+snforge_std.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/erc20/Scarb.toml
+++ b/listings/applications/erc20/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "erc20"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [lib]
 

--- a/listings/applications/merkle_tree/Scarb.toml
+++ b/listings/applications/merkle_tree/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "merkle_tree"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/nft_dutch_auction/Scarb.toml
+++ b/listings/applications/nft_dutch_auction/Scarb.toml
@@ -10,7 +10,6 @@ starknet.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
-cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/nft_dutch_auction/Scarb.toml
+++ b/listings/applications/nft_dutch_auction/Scarb.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 [dependencies]
 erc20 = { path = "../erc20" }
 starknet.workspace = true
-snforge_std.workspace = true
 
 [dev-dependencies]
 assert_macros.workspace = true
+snforge_std.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/nft_dutch_auction/Scarb.toml
+++ b/listings/applications/nft_dutch_auction/Scarb.toml
@@ -10,6 +10,7 @@ starknet.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
+cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/nft_dutch_auction/Scarb.toml
+++ b/listings/applications/nft_dutch_auction/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nft_dutch_auction"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 erc20 = { path = "../erc20" }

--- a/listings/applications/simple_storage_starknetjs/Scarb.toml
+++ b/listings/applications/simple_storage_starknetjs/Scarb.toml
@@ -3,8 +3,6 @@ name = "simple_storage"
 version.workspace = true
 edition.workspace = true
 
-[lib]
-
 [dependencies]
 starknet.workspace = true
 

--- a/listings/applications/simple_storage_starknetjs/Scarb.toml
+++ b/listings/applications/simple_storage_starknetjs/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple_storage"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [lib]
 

--- a/listings/applications/simple_vault/Scarb.toml
+++ b/listings/applications/simple_vault/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple_vault"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/staking/Scarb.toml
+++ b/listings/applications/staking/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "staking"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/timelock/Scarb.toml
+++ b/listings/applications/timelock/Scarb.toml
@@ -11,7 +11,6 @@ components.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
-cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/timelock/Scarb.toml
+++ b/listings/applications/timelock/Scarb.toml
@@ -5,12 +5,12 @@ edition.workspace = true
 
 [dependencies]
 starknet.workspace = true
-snforge_std.workspace = true
 openzeppelin.workspace = true
 components.workspace = true
 
 [dev-dependencies]
 assert_macros.workspace = true
+snforge_std.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/timelock/Scarb.toml
+++ b/listings/applications/timelock/Scarb.toml
@@ -16,4 +16,3 @@ snforge_std.workspace = true
 test.workspace = true
 
 [[target.starknet-contract]]
-casm = true

--- a/listings/applications/timelock/Scarb.toml
+++ b/listings/applications/timelock/Scarb.toml
@@ -11,6 +11,7 @@ components.workspace = true
 [dev-dependencies]
 assert_macros.workspace = true
 snforge_std.workspace = true
+cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/applications/timelock/Scarb.toml
+++ b/listings/applications/timelock/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "timelock"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/applications/upgradeable_contract/Scarb.toml
+++ b/listings/applications/upgradeable_contract/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "upgradeable_contract"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/bytearray/Scarb.toml
+++ b/listings/getting-started/bytearray/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bytearray"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/cairo_cheatsheet/Scarb.toml
+++ b/listings/getting-started/cairo_cheatsheet/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cairo_cheatsheet"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/calling_other_contracts/Scarb.toml
+++ b/listings/getting-started/calling_other_contracts/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "calling_other_contracts"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/constructor/Scarb.toml
+++ b/listings/getting-started/constructor/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "constructor"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/counter/Scarb.toml
+++ b/listings/getting-started/counter/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "counter"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/custom_type_serde/Scarb.toml
+++ b/listings/getting-started/custom_type_serde/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "custom_type_serde"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/errors/Scarb.toml
+++ b/listings/getting-started/errors/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "errors"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/events/Scarb.toml
+++ b/listings/getting-started/events/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "events"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/factory/Scarb.toml
+++ b/listings/getting-started/factory/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "factory"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/interfaces_traits/Scarb.toml
+++ b/listings/getting-started/interfaces_traits/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "interfaces_traits"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/mappings/Scarb.toml
+++ b/listings/getting-started/mappings/Scarb.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 starknet.workspace = true
 
 [dev-dependencies]
-cairo_test = "2.7.1"
+cairo_test.workspace = true
 
 [scripts]
 test.workspace = true

--- a/listings/getting-started/mappings/Scarb.toml
+++ b/listings/getting-started/mappings/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mappings"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/storage/Scarb.toml
+++ b/listings/getting-started/storage/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "storage"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/storing_custom_types/Scarb.toml
+++ b/listings/getting-started/storing_custom_types/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "storing_custom_types"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/testing_how_to/Scarb.toml
+++ b/listings/getting-started/testing_how_to/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "testing_how_to"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/variables/Scarb.toml
+++ b/listings/getting-started/variables/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "variables"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true

--- a/listings/getting-started/visibility/Scarb.toml
+++ b/listings/getting-started/visibility/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "visibility"
 version.workspace = true
-edition = "2024_07"
+edition.workspace = true
 
 [dependencies]
 starknet.workspace = true


### PR DESCRIPTION
### Description

- add `edition` to the workspace _Scarb.toml_ file and set all package editions to `edition.workspace = true`
- move `snforge_std` dependency to `[dev-dependencies]` where it belongs
- remove redundant `casm = true` keys
- remove redundant `[lib]` tables
- update `cairo_test` version to point to workspace's in `mappings`

### Checklist

- [x] **CI Verifier:** Run `./scripts/cairo_programs_verifier.sh` successfully