### PR TITLE
Showing the interface in the example code

### DIFF
--- a/listings/getting-started/visibility/src/visibility.cairo
+++ b/listings/getting-started/visibility/src/visibility.cairo
@@ -1,10 +1,10 @@
+// [!region contract]
 #[starknet::interface]
 pub trait IExampleContract<TContractState> {
     fn set(ref self: TContractState, value: u32);
     fn get(self: @TContractState) -> u32;
 }
 
-// [!region contract]
 #[starknet::contract]
 pub mod ExampleContract {
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};


### PR DESCRIPTION
Simple PR just to show the interface in one of the examples so that copy & pasting the contract will make the program compile & work