### PR TITLE
Typos fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ You can also use `scarb fmt` to format all the Cairo programs.
 
 ### Tests
 
-Every listing needs to have atleast integration tests:
+Every listing needs to have at least integration tests:
 
 - Integration tests are tests that deploy the contract and interact with the provided interface(s). At minimal make one test to deploy the contract.
 

--- a/pages/advanced-concepts/account_abstraction/account_contract.md
+++ b/pages/advanced-concepts/account_abstraction/account_contract.md
@@ -40,7 +40,7 @@ trait ISRC6 {
 }
 ```
 
-A transaction can be represented as a list of calls `Array<Call>` to other contracts, with atleast one call.
+A transaction can be represented as a list of calls `Array<Call>` to other contracts, with at least one call.
 
 - `__execute__`: Executes a transaction after the validation phase. Returns an array of the serialized return of value (`Span<felt252>`) of each call.
 


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /CONTRIBUTING.md (Line 178)

"atleast" → "at least"

Corrected typo in /pages/advanced-concepts/account_abstraction/account_contract.md (Line 43)

"atleast" → "at least"

**Purpose**

Improved code accuracy and professionalism by fixing typos.